### PR TITLE
Webhook: fix exception with stream reader

### DIFF
--- a/rubberduckvba.Server/GitHubAuthenticationHandler.cs
+++ b/rubberduckvba.Server/GitHubAuthenticationHandler.cs
@@ -75,7 +75,9 @@ public class WebhookAuthenticationHandler : AuthenticationHandler<Authentication
             }
 
             var signature = xHubSignature256.SingleOrDefault();
-            var payload = new StreamReader(Context.Request.Body).ReadToEnd();
+
+            using var reader = new StreamReader(Context.Request.Body);
+            var payload = reader.ReadToEndAsync().GetAwaiter().GetResult();
 
             if (!IsValidSignature(signature, payload))
             {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/300ccae4-667f-46e3-b671-49630f194fe4)

```
Category: Microsoft.AspNetCore.Server.IIS.Core.IISHttpServer
EventId: 2
SpanId: d1d77d61055155f3
TraceId: c9a27a7446dd45e72696d2d8d1cf4913
ParentId: 0000000000000000
RequestId: 40000ae8-0000-f000-b63f-84710c7967bb
RequestPath: /webhook/github

Connection ID "17293822569908013799", Request ID "40000ae8-0000-f000-b63f-84710c7967bb": An unhandled exception was thrown by the application.

Exception: 
System.InvalidOperationException: Synchronous operations are disallowed. Call ReadAsync or set AllowSynchronousIO to true instead.
   at Microsoft.AspNetCore.Server.IIS.Core.HttpRequestStream.Read(Byte[] buffer, Int32 offset, Int32 count)
   at System.IO.StreamReader.ReadBuffer()
   at System.IO.StreamReader.ReadToEnd()
   at rubberduckvba.Server.WebhookAuthenticationHandler.<HandleAuthenticateAsync>b__2_0() in D:\a\rubberduckvba-website\rubberduckvba-website\rubberduckvba.Server\GitHubAuthenticationHandler.cs:line 78
```