### PR TITLE
Fix inspections/quickfix cache validation issue

### DIFF
--- a/rubberduckvba.Server/Api/Admin/AdminController.cs
+++ b/rubberduckvba.Server/Api/Admin/AdminController.cs
@@ -46,6 +46,7 @@ public class AdminController(ConfigurationOptions options, HangfireLauncherServi
     }
 
 #if DEBUG
+    [EnableCors("CorsPolicy")]
     [HttpGet("admin/config/current")]
     public IActionResult Config()
     {

--- a/rubberduckvba.Server/Api/Admin/AdminController.cs
+++ b/rubberduckvba.Server/Api/Admin/AdminController.cs
@@ -6,7 +6,6 @@ using rubberduckvba.Server.Services;
 
 namespace rubberduckvba.Server.Api.Admin;
 
-
 [ApiController]
 public class AdminController(ConfigurationOptions options, HangfireLauncherService hangfire, CacheService cache) : ControllerBase
 {
@@ -15,7 +14,7 @@ public class AdminController(ConfigurationOptions options, HangfireLauncherServi
     /// </summary>
     /// <returns>The unique identifier of the enqueued job.</returns>
     [Authorize("github")]
-    [EnableCors("CorsPolicy")]
+    [EnableCors(CorsPolicies.AllowAuthenticated)]
     [HttpPost("admin/update/xmldoc")]
     public IActionResult UpdateXmldocContent()
     {
@@ -28,7 +27,7 @@ public class AdminController(ConfigurationOptions options, HangfireLauncherServi
     /// </summary>
     /// <returns>The unique identifier of the enqueued job.</returns>
     [Authorize("github")]
-    [EnableCors("CorsPolicy")]
+    [EnableCors(CorsPolicies.AllowAuthenticated)]
     [HttpPost("admin/update/tags")]
     public IActionResult UpdateTagMetadata()
     {
@@ -37,7 +36,7 @@ public class AdminController(ConfigurationOptions options, HangfireLauncherServi
     }
 
     [Authorize("github")]
-    [EnableCors("CorsPolicy")]
+    [EnableCors(CorsPolicies.AllowAuthenticated)]
     [HttpPost("admin/cache/clear")]
     public IActionResult ClearCache()
     {
@@ -46,7 +45,8 @@ public class AdminController(ConfigurationOptions options, HangfireLauncherServi
     }
 
 #if DEBUG
-    [EnableCors("CorsPolicy")]
+    [AllowAnonymous]
+    [EnableCors(CorsPolicies.AllowAll)]
     [HttpGet("admin/config/current")]
     public IActionResult Config()
     {

--- a/rubberduckvba.Server/Api/Admin/WebhookController.cs
+++ b/rubberduckvba.Server/Api/Admin/WebhookController.cs
@@ -22,7 +22,7 @@ public class WebhookController : RubberduckApiController
     }
 
     [Authorize("webhook")]
-    [EnableCors("webhookPolicy")]
+    [EnableCors(CorsPolicies.AllowAll)]
     [HttpPost("webhook/github")]
     public async Task<IActionResult> GitHub([FromBody] dynamic body) =>
         GuardInternalAction(() =>

--- a/rubberduckvba.Server/Api/Auth/AuthController.cs
+++ b/rubberduckvba.Server/Api/Auth/AuthController.cs
@@ -37,7 +37,7 @@ public class AuthController : RubberduckApiController
     }
 
     [HttpGet("auth")]
-    [EnableCors("CorsPolicy")]
+    [EnableCors(CorsPolicies.AllowAll)]
     [AllowAnonymous]
     public IActionResult Index()
     {
@@ -72,7 +72,7 @@ public class AuthController : RubberduckApiController
     }
 
     [HttpPost("auth/signin")]
-    [EnableCors("CorsPolicy")]
+    [EnableCors(CorsPolicies.AllowAll)]
     [AllowAnonymous]
     public IActionResult SessionSignIn(SignInViewModel vm)
     {
@@ -109,7 +109,7 @@ public class AuthController : RubberduckApiController
     }
 
     [HttpPost("auth/github")]
-    [EnableCors("CorsPolicy")]
+    [EnableCors(CorsPolicies.AllowAll)]
     [AllowAnonymous]
     public IActionResult OnGitHubCallback(SignInViewModel vm)
     {

--- a/rubberduckvba.Server/Api/Auth/AuthController.cs
+++ b/rubberduckvba.Server/Api/Auth/AuthController.cs
@@ -37,6 +37,7 @@ public class AuthController : RubberduckApiController
     }
 
     [HttpGet("auth")]
+    [EnableCors("CorsPolicy")]
     [AllowAnonymous]
     public IActionResult Index()
     {

--- a/rubberduckvba.Server/Api/Downloads/DownloadsController.cs
+++ b/rubberduckvba.Server/Api/Downloads/DownloadsController.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Mvc;
 using rubberduckvba.Server.Services;
 using System.Collections.Immutable;
@@ -7,6 +8,7 @@ namespace rubberduckvba.Server.Api.Downloads;
 
 
 [AllowAnonymous]
+[EnableCors(CorsPolicies.AllowAll)]
 public class DownloadsController : RubberduckApiController
 {
     private readonly CacheService cache;

--- a/rubberduckvba.Server/Api/Features/FeatureViewModel.cs
+++ b/rubberduckvba.Server/Api/Features/FeatureViewModel.cs
@@ -55,7 +55,7 @@ public class FeatureViewModel
 
 public class InspectionViewModel
 {
-    public InspectionViewModel(Inspection model, IDictionary<int, Tag> tagsByAssetId)
+    public InspectionViewModel(Inspection model, IEnumerable<QuickFixViewModel> quickFixes, IDictionary<int, Tag> tagsByAssetId)
     {
         Id = model.Id;
         DateTimeInserted = model.DateTimeInserted;
@@ -78,7 +78,7 @@ public class InspectionViewModel
 
         InspectionType = model.InspectionType;
         DefaultSeverity = model.DefaultSeverity;
-        QuickFixes = model.QuickFixes;
+        QuickFixes = quickFixes.Where(e => model.QuickFixes.Any(name => string.Equals(e.Name, name, StringComparison.InvariantCultureIgnoreCase))).ToArray();
 
         Reasoning = model.Reasoning;
         HostApp = model.HostApp;
@@ -110,7 +110,7 @@ public class InspectionViewModel
     public string? Remarks { get; init; }
     public string? HostApp { get; init; }
     public string[] References { get; init; } = [];
-    public string[] QuickFixes { get; init; } = [];
+    public QuickFixViewModel[] QuickFixes { get; init; } = [];
     public InspectionExample[] Examples { get; init; } = [];
 }
 
@@ -239,11 +239,11 @@ public record class QuickFixInspectionLinkViewModel
 
 public class InspectionsFeatureViewModel : FeatureViewModel
 {
-    public InspectionsFeatureViewModel(FeatureGraph model, IDictionary<int, Tag> tagsByAssetId, bool summaryOnly = false)
+    public InspectionsFeatureViewModel(FeatureGraph model, IEnumerable<QuickFixViewModel> quickFixes, IDictionary<int, Tag> tagsByAssetId, bool summaryOnly = false)
         : base(model, summaryOnly)
     {
 
-        Inspections = model.Inspections.OrderBy(e => e.Name).Select(e => new InspectionViewModel(e, tagsByAssetId)).ToArray();
+        Inspections = model.Inspections.OrderBy(e => e.Name).Select(e => new InspectionViewModel(e, quickFixes, tagsByAssetId)).ToArray();
     }
 
     public InspectionViewModel[] Inspections { get; init; } = [];

--- a/rubberduckvba.Server/Api/Features/FeaturesController.cs
+++ b/rubberduckvba.Server/Api/Features/FeaturesController.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Mvc;
 using rubberduckvba.Server.Data;
 using rubberduckvba.Server.Model;
@@ -37,6 +38,7 @@ public class FeaturesController : RubberduckApiController
             .ContinueWith(t => t.Result.Select(e => new FeatureOptionViewModel { Id = e.Id, Name = e.Name, Title = e.Title }).ToArray());
 
     [HttpGet("features")]
+    [EnableCors(CorsPolicies.AllowAll)]
     [AllowAnonymous]
     public IActionResult Index()
     {
@@ -66,6 +68,7 @@ public class FeaturesController : RubberduckApiController
     }
 
     [HttpGet("features/{name}")]
+    [EnableCors(CorsPolicies.AllowAll)]
     [AllowAnonymous]
     public IActionResult Info([FromRoute] string name)
     {
@@ -82,6 +85,7 @@ public class FeaturesController : RubberduckApiController
     }
 
     [HttpGet("inspections/{name}")]
+    [EnableCors(CorsPolicies.AllowAll)]
     [AllowAnonymous]
     public IActionResult Inspection([FromRoute] string name)
     {
@@ -103,6 +107,7 @@ public class FeaturesController : RubberduckApiController
     }
 
     [HttpGet("annotations/{name}")]
+    [EnableCors(CorsPolicies.AllowAll)]
     [AllowAnonymous]
     public IActionResult Annotation([FromRoute] string name)
     {
@@ -124,6 +129,7 @@ public class FeaturesController : RubberduckApiController
     }
 
     [HttpGet("quickfixes/{name}")]
+    [EnableCors(CorsPolicies.AllowAll)]
     [AllowAnonymous]
     public IActionResult QuickFix([FromRoute] string name)
     {
@@ -145,6 +151,7 @@ public class FeaturesController : RubberduckApiController
     }
 
     [HttpGet("features/create")]
+    [EnableCors(CorsPolicies.AllowAuthenticated)]
     [Authorize("github")]
     public async Task<ActionResult<FeatureEditViewModel>> Create([FromQuery] RepositoryId repository = RepositoryId.Rubberduck, [FromQuery] int? parentId = default)
     {
@@ -156,6 +163,7 @@ public class FeaturesController : RubberduckApiController
     }
 
     [HttpPost("create")]
+    [EnableCors(CorsPolicies.AllowAuthenticated)]
     [Authorize("github")]
     public async Task<ActionResult<FeatureEditViewModel>> Create([FromBody] FeatureEditViewModel model)
     {
@@ -178,6 +186,7 @@ public class FeaturesController : RubberduckApiController
     }
 
     [HttpPost("features/update")]
+    [EnableCors(CorsPolicies.AllowAuthenticated)]
     [Authorize("github")]
     public async Task<ActionResult<FeatureEditViewModel>> Update([FromBody] FeatureEditViewModel model)
     {
@@ -203,8 +212,10 @@ public class FeaturesController : RubberduckApiController
         InspectionsFeatureViewModel result;
         if (!cache.TryGetInspections(out result!))
         {
+            var quickfixesModel = GetQuickFixes();
+
             var feature = features.Get("Inspections") as FeatureGraph;
-            result = new InspectionsFeatureViewModel(feature,
+            result = new InspectionsFeatureViewModel(feature, quickfixesModel.QuickFixes,
                 feature.Inspections
                     .Select(e => e.TagAssetId).Distinct()
                     .ToDictionary(id => id, id => new Tag(tagsRepository.GetById(assetsRepository.GetById(id).TagId))));

--- a/rubberduckvba.Server/Api/Indenter/IndenterController.cs
+++ b/rubberduckvba.Server/Api/Indenter/IndenterController.cs
@@ -1,10 +1,12 @@
 ﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Mvc;
 using RubberduckServices;
 
 namespace rubberduckvba.Server.Api.Indenter;
 
 [AllowAnonymous]
+[EnableCors(CorsPolicies.AllowAll)]
 public class IndenterController : RubberduckApiController
 {
     private readonly IIndenterService service;

--- a/rubberduckvba.Server/Api/Tags/TagsController.cs
+++ b/rubberduckvba.Server/Api/Tags/TagsController.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Mvc;
 using rubberduckvba.Server.Services;
 
@@ -6,6 +7,7 @@ namespace rubberduckvba.Server.Api.Tags;
 
 
 [AllowAnonymous]
+[EnableCors(CorsPolicies.AllowAll)]
 public class TagsController : RubberduckApiController
 {
     private readonly CacheService cache;
@@ -23,7 +25,6 @@ public class TagsController : RubberduckApiController
     /// </summary>
     [HttpGet("api/v1/public/tags")] // legacy route
     [HttpGet("tags/latest")]
-    [AllowAnonymous]
     public IActionResult Latest()
     {
         return GuardInternalAction(() =>

--- a/rubberduckvba.Server/ContentSynchronization/Pipeline/Sections/Context/SyncContext.cs
+++ b/rubberduckvba.Server/ContentSynchronization/Pipeline/Sections/Context/SyncContext.cs
@@ -21,7 +21,6 @@ public class SyncContext : IPipelineContext
     IRequestParameters IPipelineContext.Parameters => Parameters;
     public void LoadParameters(SyncRequestParameters parameters)
     {
-        InvalidContextParameterException.ThrowIfNull(nameof(parameters), parameters);
         _parameters = parameters;
         _staging = new StagingContext(parameters);
     }

--- a/rubberduckvba.Server/GitHubAuthenticationHandler.cs
+++ b/rubberduckvba.Server/GitHubAuthenticationHandler.cs
@@ -25,7 +25,7 @@ public class GitHubAuthenticationHandler : AuthenticationHandler<AuthenticationS
             var token = Context.Request.Headers["X-ACCESS-TOKEN"].SingleOrDefault();
             if (string.IsNullOrWhiteSpace(token))
             {
-                return AuthenticateResult.NoResult();
+                return AuthenticateResult.Fail("Access token was not provided");
             }
 
             var principal = await _github.ValidateTokenAsync(token);
@@ -36,7 +36,7 @@ public class GitHubAuthenticationHandler : AuthenticationHandler<AuthenticationS
                 return AuthenticateResult.Success(new AuthenticationTicket(principal, "github"));
             }
 
-            return AuthenticateResult.NoResult();
+            return AuthenticateResult.Fail("An invalid access token was provided");
         }
         catch (InvalidOperationException e)
         {

--- a/rubberduckvba.Server/Program.cs
+++ b/rubberduckvba.Server/Program.cs
@@ -51,7 +51,6 @@ public class Program
             {
                 policy
                     .SetIsOriginAllowed(origin => true)
-                    .AllowAnyOrigin()
                     .AllowAnyHeader()
                     .WithMethods("OPTIONS", "GET", "POST")
                     .AllowCredentials()

--- a/rubberduckvba.Server/Program.cs
+++ b/rubberduckvba.Server/Program.cs
@@ -51,6 +51,7 @@ public class Program
             {
                 policy
                     .SetIsOriginAllowed(origin => true)
+                    .AllowAnyOrigin()
                     .AllowAnyHeader()
                     .WithMethods("OPTIONS", "GET", "POST")
                     .AllowCredentials()

--- a/rubberduckvba.client/src/app/app.module.ts
+++ b/rubberduckvba.client/src/app/app.module.ts
@@ -86,17 +86,18 @@ export class LowerCaseUrlSerializer extends DefaultUrlSerializer {
     BrowserModule,
     FormsModule,
     RouterModule.forRoot([
-      { path: '', component: HomeComponent, pathMatch: 'full' },
+      // legacy routes:
+      { path: 'inspections/details/:name', redirectTo: 'inspections/:name' },
+      // actual routes:
+      { path: 'auth/github', component: AuthComponent },
       { path: 'features', component: FeaturesComponent },
       { path: 'features/:name', component: FeatureComponent },
       { path: 'inspections/:name', component: InspectionComponent },
       { path: 'annotations/:name', component: AnnotationComponent },
       { path: 'quickfixes/:name', component: QuickFixComponent },
       { path: 'about', component: AboutComponent },
-      { path: 'auth/github', component: AuthComponent },
       { path: 'indenter', component: IndenterComponent },
-      // legacy routes:
-      { path: 'inspections/details/:name', redirectTo: 'inspections/:name' },
+      { path: '', component: HomeComponent, pathMatch: 'full' },
     ]),
     FontAwesomeModule,
     NgbModule

--- a/rubberduckvba.client/src/app/components/auth-menu/auth-menu.component.html
+++ b/rubberduckvba.client/src/app/components/auth-menu/auth-menu.component.html
@@ -55,7 +55,7 @@
             </div>
             <div class="modal-footer">
                 <button id="cancel-login" type="button" class="btn btn-secondary" data-dismiss="modal" aria-label="Close" (click)="modal.dismiss('cancel')">Close</button>
-                <button id="accept-login" type="button" class="btn btn-danger" (click)="signin()">Accept</button>
+                <button id="accept-login" type="button" class="btn btn-danger" data-dismiss="modal" (click)="signin()">Accept</button>
             </div>
         </div>
     </div>

--- a/rubberduckvba.client/src/app/components/auth-menu/auth-menu.component.ts
+++ b/rubberduckvba.client/src/app/components/auth-menu/auth-menu.component.ts
@@ -64,7 +64,6 @@ export class AuthMenuComponent implements OnInit {
 
   public signin(): void {
     this.auth.signin();
-    this.getUserInfo();
   }
 
   public signout(): void {

--- a/rubberduckvba.client/src/app/components/feature-info/feature-info.component.html
+++ b/rubberduckvba.client/src/app/components/feature-info/feature-info.component.html
@@ -10,7 +10,7 @@
             <!-- subfeatures -->
             <div *ngIf="feature != null && subfeatures != null && (subfeatures.length ?? 0) > 0">
                 <div *ngFor="let subFeature of subfeatures">
-                    <feature-box *ngIf="!feature.isHidden && (subFeature.name=='Inspections' || subFeature.name=='QuickFixes' || subFeature.name=='Annotations')" [parentFeatureName]="feature.name" [feature]="subFeature" [quickFixes]="quickFixes" [hasOwnDetailsPage]="true"></feature-box>
+                    <feature-box *ngIf="!feature.isHidden && (subFeature.name=='Inspections' || subFeature.name=='QuickFixes' || subFeature.name=='Annotations')" [parentFeatureName]="feature.name" [feature]="subFeature" [hasOwnDetailsPage]="true"></feature-box>
                 </div>
             </div>
 
@@ -35,7 +35,7 @@
     <!-- subfeatures -->
     <div *ngIf="feature != null && subfeatures != null && (subfeatures.length ?? 0) > 0" class="col-12">
         <div *ngFor="let subFeature of subfeatures">
-            <feature-box *ngIf="!feature.isHidden && !(subFeature.name=='Inspections' || subFeature.name=='QuickFixes' || subFeature.name=='Annotations')" [parentFeatureName]="feature.name" [feature]="subFeature" [quickFixes]="quickFixes" [hasOwnDetailsPage]="false"></feature-box>
+            <feature-box *ngIf="!feature.isHidden && !(subFeature.name=='Inspections' || subFeature.name=='QuickFixes' || subFeature.name=='Annotations')" [parentFeatureName]="feature.name" [feature]="subFeature" [hasOwnDetailsPage]="false"></feature-box>
         </div>
     </div>
 
@@ -84,7 +84,7 @@
         <div *ngIf="feature?.name == 'Inspections'" class="row">
             <div class="card-columns">
                 <div *ngFor="let item of filteredItems">
-                    <inspection-item-box *ngIf="!item.isHidden" [item]="item" [quickFixes]="quickFixes"></inspection-item-box>
+                    <inspection-item-box *ngIf="!item.isHidden" [item]="item"></inspection-item-box>
                 </div>
             </div>
         </div>

--- a/rubberduckvba.client/src/app/components/feature-info/feature-info.component.ts
+++ b/rubberduckvba.client/src/app/components/feature-info/feature-info.component.ts
@@ -63,17 +63,6 @@ export class FeatureInfoComponent implements OnInit, OnChanges {
     return (this.feature as FeatureViewModel)?.features ?? [];
   }
 
-  @Input()
-  public set quickFixes(value: QuickFixViewModel[]) {
-    if (value != null) {
-      this._quickfixes.next(value);
-    }
-  }
-
-  public get quickFixes(): QuickFixViewModel[] {
-    return this._quickfixes.value;
-  }
-
   public get links(): BlogLink[] {
     let feature = <FeatureViewModel>this.feature;
     return feature?.links ?? [];

--- a/rubberduckvba.client/src/app/components/feature-item-box/inspection-item-box/inspection-item-box.component.html
+++ b/rubberduckvba.client/src/app/components/feature-item-box/inspection-item-box/inspection-item-box.component.html
@@ -91,10 +91,10 @@
                         <p class="small">This inspection offers the following fixes:</p>
                         <ul class="list-unstyled ms-2">
                             <li *ngFor="let fix of this.inspectionInfo.quickFixes" class="my-1">
-                                <a class="text-decoration-none" href="/quickfixes/{{fix}}">
+                                <a class="text-decoration-none" href="/quickfixes/{{fix.name}}">
                                     <div class="card-highlight rounded-4 p-2">
-                                        <h6><fa-icon [icon]="'circle-check'"></fa-icon>&nbsp;{{fix.replace('QuickFix','')}}</h6>
-                                        <p class="text-black-50 small" [innerHTML]="getQuickFixSummary(fix)"></p>
+                                        <h6><fa-icon [icon]="'circle-check'"></fa-icon>&nbsp;{{fix.name}}</h6>
+                                        <p class="text-black-50 small" [innerHTML]="fix.summary"></p>
                                     </div>
                                 </a>
                             </li>

--- a/rubberduckvba.client/src/app/model/feature.model.ts
+++ b/rubberduckvba.client/src/app/model/feature.model.ts
@@ -108,7 +108,7 @@ export interface InspectionViewModel extends XmlDocViewModel {
   hostApp?: string;
 
   references: string[];
-  quickFixes: string[];
+  quickFixes: QuickFixViewModel[];
 
   examples: InspectionExample[];
 
@@ -280,7 +280,7 @@ export class InspectionViewModelClass extends SubFeatureViewModelClass implement
   remarks?: string | undefined;
   hostApp?: string | undefined;
   references: string[];
-  quickFixes: string[];
+  quickFixes: QuickFixViewModel[];
   examples: InspectionExample[];
   tagAssetId: number;
   tagName: string;

--- a/rubberduckvba.client/src/app/routes/inspection/inspection.component.html
+++ b/rubberduckvba.client/src/app/routes/inspection/inspection.component.html
@@ -1,6 +1,7 @@
 <p *ngIf="(info?.featureId) && info?.featureId != 0"><a href="/">Home</a>▸<a href="/features">Features</a>▸<a href="/features/codeinspections">CodeInspections</a>▸<a href="/features/inspections">Inspections</a>▸</p>
-<h1>{{info.title}}</h1>
-<div class="row">
+<h1 *ngIf="info">{{info.title}}</h1>
+<p *ngIf="info" class="fw-medium" [innerHtml]="info.summary"></p>
+<div *ngIf="info" class="row">
     <div class="text-start">
         <div class="row">
             <div>
@@ -29,8 +30,8 @@
             </div>
         </div>
         <div class="row">
+            <hr />
             <div class="col-11 ms-2">
-                <p class="fw-medium" [innerHtml]="info.summary"></p>
                 <p [innerHtml]="info.reasoning"></p>
             </div>
         </div>
@@ -67,10 +68,10 @@
                 <p class="small">This inspection offers the following fixes:</p>
                 <ul class="list-unstyled ms-2">
                     <li *ngFor="let fix of this.info.quickFixes" class="my-1">
-                        <a class="text-decoration-none" href="/quickfixes/{{fix}}">
+                        <a class="text-decoration-none" href="/quickfixes/{{fix.name}}">
                             <div class="card-highlight rounded-4 p-2">
-                                <h6><fa-icon [icon]="'circle-check'"></fa-icon>&nbsp;{{fix.replace('QuickFix','')}}</h6>
-                                <!-- <p class="text-black-50 small" [innerHTML]="getQuickFixSummary(fix)"></p> -->
+                                <h6><fa-icon [icon]="'circle-check'"></fa-icon>&nbsp;{{fix.name}}</h6>
+                                <p class="text-black-50 small mx-2">{{fix.summary}}</p>
                             </div>
                         </a>
                     </li>

--- a/rubberduckvba.client/src/app/routes/inspection/inspection.component.ts
+++ b/rubberduckvba.client/src/app/routes/inspection/inspection.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from "@angular/core";
 import { InspectionViewModel } from "../../model/feature.model";
-import { ActivatedRoute } from "@angular/router";
+import { ActivatedRoute, Router } from "@angular/router";
 import { FaIconLibrary } from "@fortawesome/angular-fontawesome";
 import { fas } from "@fortawesome/free-solid-svg-icons";
 import { BehaviorSubject, switchMap } from "rxjs";
@@ -21,7 +21,7 @@ export class InspectionComponent implements OnInit {
     return this._info.getValue();
   }
 
-  constructor(private api: ApiClientService, private fa: FaIconLibrary, private route: ActivatedRoute) {
+  constructor(private api: ApiClientService, private fa: FaIconLibrary, private route: ActivatedRoute, private router: Router) {
     fa.addIconPacks(fas);
   }
 
@@ -31,6 +31,7 @@ export class InspectionComponent implements OnInit {
         const name = params.get('name')!;
         return this.api.getInspection(name);
       })).subscribe(e => {
+        console.log(e);
         this.info = <InspectionViewModel>e;
       });
   }

--- a/rubberduckvba.client/src/app/services/auth.service.ts
+++ b/rubberduckvba.client/src/app/services/auth.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from "@angular/core";
-import { Observable } from "rxjs";
+import { Observable, map } from "rxjs";
 import { environment } from "../../environments/environment";
 import { UserViewModel } from "../model/feature.model";
 import { AuthViewModel, DataService } from "./data.service";
@@ -12,6 +12,11 @@ export class AuthService {
 
   private sleep(ms: number): Promise<void> {
     return new Promise(resolve => setTimeout(resolve, ms));
+  }
+
+  private redirect(url: string = '/'): void {
+    console.log(`redirecting: ${url}`);
+    window.location.href = url;
   }
 
   private writeStorage(key: string, value: string): void {
@@ -32,7 +37,7 @@ export class AuthService {
 
     const url = `${environment.apiBaseUrl}auth/signin`;
     this.data.postAsync<AuthViewModel, string>(url, vm)
-      .subscribe(redirectUrl => location.href = redirectUrl);
+      .subscribe((result: string) => this.redirect(result));
   }
 
   public signout(): void {
@@ -52,17 +57,17 @@ export class AuthService {
         this.data.postAsync<AuthViewModel, AuthViewModel>(url, vm)
           .subscribe(result => {
             this.writeStorage('github:access_token', result.token!);
-            location.href = '/';
+            this.redirect();
           });
       }
       catch (error) {
         console.log(error);
-        location.href = '/';
+        this.redirect();
       }
     }
     else {
       console.log('xsrf:state mismatched!');
-      location.href = '/';
+      this.redirect();
     }
   }
 }

--- a/rubberduckvba.client/src/app/services/data.service.ts
+++ b/rubberduckvba.client/src/app/services/data.service.ts
@@ -36,6 +36,7 @@ export class DataService {
       .append('Access-Control-Allow-Origin', '*')
       .append('accept', 'application/json')
       .append('Content-Type', 'application/json; charset=utf-8');
+
     const token = sessionStorage.getItem('github:access_token');
     let withCreds = false;
     if (token) {
@@ -44,8 +45,8 @@ export class DataService {
     }
 
     return (content
-      ? this.http.post(url, content, { headers, withCredentials:withCreds })
-      : this.http.post(url, { headers, withCredentials: withCreds }))
+      ? this.http.post(url, content, { headers, withCredentials: withCreds })
+      : this.http.post(url, null, { headers, withCredentials: withCreds }))
       .pipe(
         map(result => <TResult>result),
         timeout(this.timeout),

--- a/rubberduckvba.client/src/environments/environment.test.ts
+++ b/rubberduckvba.client/src/environments/environment.test.ts
@@ -1,4 +1,4 @@
 export const environment = {
-  production: true,
-  apiBaseUrl: 'https://test.api.rubberduckvba.com/'
+  production: false,
+  apiBaseUrl: 'https://localhost:44314/'
 };


### PR DESCRIPTION
Non-successful last xmldoc udpate run would prevent things from being written to cache, and a bug would then prevent serving the inspections and quickfix details pages.